### PR TITLE
Small improvements on the manager window UI.

### DIFF
--- a/resources/manager_window.ui
+++ b/resources/manager_window.ui
@@ -46,7 +46,6 @@
     <property name="border_width">3</property>
     <property name="title" translatable="yes">Package Manager</property>
     <property name="window_position">center</property>
-    <property name="default_width">900</property>
     <property name="default_height">600</property>
     <property name="icon_name">system-software-install</property>
     <child>
@@ -438,6 +437,7 @@
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow" id="scrolledwindow6">
+                    <property name="width_request">500</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="hexpand">True</property>
@@ -445,8 +445,6 @@
                     <property name="shadow_type">in</property>
                     <child>
                       <object class="GtkTreeView" id="packages_treeview">
-                        <property name="width_request">500</property>
-                        <property name="height_request">300</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="hexpand">True</property>
@@ -471,7 +469,7 @@
                             <child>
                               <object class="GtkCellRendererPixbuf" id="state_rendererpixbuf">
                                 <property name="width">40</property>
-                                <property name="height">20</property>
+                                <property name="height">22</property>
                               </object>
                               <attributes>
                                 <attribute name="pixbuf">1</attribute>
@@ -484,12 +482,13 @@
                             <property name="resizable">True</property>
                             <property name="min_width">20</property>
                             <property name="title" translatable="yes">Name</property>
+                            <property name="expand">True</property>
                             <property name="clickable">True</property>
                             <signal name="clicked" handler="on_name_column_clicked" swapped="no"/>
                             <child>
                               <object class="GtkCellRendererText" id="name_renderertext">
                                 <property name="width">150</property>
-                                <property name="height">20</property>
+                                <property name="height">22</property>
                               </object>
                               <attributes>
                                 <attribute name="text">0</attribute>
@@ -506,8 +505,8 @@
                             <signal name="clicked" handler="on_version_column_clicked" swapped="no"/>
                             <child>
                               <object class="GtkCellRendererText" id="version_renderertext">
-                                <property name="width">80</property>
-                                <property name="height">20</property>
+                                <property name="width">90</property>
+                                <property name="height">22</property>
                               </object>
                               <attributes>
                                 <attribute name="text">2</attribute>
@@ -524,8 +523,8 @@
                             <signal name="clicked" handler="on_repo_column_clicked" swapped="no"/>
                             <child>
                               <object class="GtkCellRendererText" id="repo_renderertext">
-                                <property name="width">80</property>
-                                <property name="height">20</property>
+                                <property name="width">90</property>
+                                <property name="height">22</property>
                               </object>
                               <attributes>
                                 <attribute name="text">3</attribute>
@@ -542,8 +541,8 @@
                             <signal name="clicked" handler="on_size_column_clicked" swapped="no"/>
                             <child>
                               <object class="GtkCellRendererText" id="size_renderertext">
-                                <property name="width">80</property>
-                                <property name="height">20</property>
+                                <property name="width">90</property>
+                                <property name="height">22</property>
                               </object>
                               <attributes>
                                 <attribute name="text">4</attribute>
@@ -823,7 +822,7 @@
             </child>
           </object>
           <packing>
-            <property name="expand">False</property>
+            <property name="expand">True</property>
             <property name="fill">True</property>
             <property name="position">1</property>
           </packing>


### PR DESCRIPTION
* Set width only for the closest component instead of the whole window.
* Increase rows height of packages_treeview from 20 to 22 so that we can
  see the tails of the 'j's and 'g's (there must be a better way than forcing
  the height, but I didn't find it).
* Increase a little the columns width, based on the average text
  displayed in them.
* Set 'Name' column expandable, meaning that when you resize the window,
  it will be this column that will take the width difference, which is
  probably what the users want to do 95% of the time.
* Set the window expandable. This doesn't change anything, but offers a
  better display in Glade.