### PR TITLE
[Feature Request] Hide tray icon when no updates are available

### DIFF
--- a/data/config/pamac.conf
+++ b/data/config/pamac.conf
@@ -9,3 +9,6 @@ EnableAUR
 ## When removing a package, also remove those dependencies
 ## that are not required by other packages (recurse option):
 #RemoveUnrequiredDeps
+
+## When there are no updates to download, hide the tray icon:
+#NoUpdateHideIcon

--- a/resources/preferences_dialog.ui
+++ b/resources/preferences_dialog.ui
@@ -111,6 +111,18 @@
                   </packing>
                 </child>
                 <child>
+                  <object class="GtkSwitch" id="noupdate_hide_icon_button">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="tooltip_text" translatable="yes">Hide tray icon when there are no updates available</property>
+                    <property name="halign">start</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">3</property>
+                  </packing>
+                </child>
+                <child>
                   <object class="GtkEntry" id="syncfirst_entry">
                     <property name="width_request">300</property>
                     <property name="visible">True</property>
@@ -119,7 +131,7 @@
                   </object>
                   <packing>
                     <property name="left_attach">1</property>
-                    <property name="top_attach">3</property>
+                    <property name="top_attach">4</property>
                   </packing>
                 </child>
                 <child>
@@ -131,7 +143,7 @@
                   </object>
                   <packing>
                     <property name="left_attach">1</property>
-                    <property name="top_attach">4</property>
+                    <property name="top_attach">5</property>
                   </packing>
                 </child>
                 <child>
@@ -149,7 +161,7 @@
                   </object>
                   <packing>
                     <property name="left_attach">1</property>
-                    <property name="top_attach">5</property>
+                    <property name="top_attach">6</property>
                   </packing>
                 </child>
                 <child>
@@ -177,6 +189,18 @@
                   </packing>
                 </child>
                 <child>
+                  <object class="GtkLabel" id="noupdate_hide_icon_label">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">end</property>
+                    <property name="label" translatable="yes">Hide tray icon when there are no updates</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">3</property>
+                  </packing>
+                </child>
+                <child>
                   <object class="GtkLabel" id="syncfirst_label">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
@@ -185,7 +209,7 @@
                   </object>
                   <packing>
                     <property name="left_attach">0</property>
-                    <property name="top_attach">3</property>
+                    <property name="top_attach">4</property>
                   </packing>
                 </child>
                 <child>
@@ -197,7 +221,7 @@
                   </object>
                   <packing>
                     <property name="left_attach">0</property>
-                    <property name="top_attach">4</property>
+                    <property name="top_attach">5</property>
                   </packing>
                 </child>
                 <child>
@@ -208,7 +232,7 @@
                   </object>
                   <packing>
                     <property name="left_attach">0</property>
-                    <property name="top_attach">5</property>
+                    <property name="top_attach">6</property>
                   </packing>
                 </child>
                 <child>

--- a/src/pamac_config.vala
+++ b/src/pamac_config.vala
@@ -23,6 +23,7 @@ namespace Pamac {
 		public int refresh_period;
 		public bool enable_aur;
 		public bool recurse;
+		public bool noupdate_hide_icon;
 
 		public Config (string path) {
 			conf_path = path;
@@ -35,6 +36,7 @@ namespace Pamac {
 			// set default options
 			enable_aur = false;
 			recurse = false;
+			noupdate_hide_icon = false;
 			parse_file (conf_path);
 		}
 
@@ -69,6 +71,8 @@ namespace Pamac {
 							enable_aur = true;
 						} else if (_key == "RemoveUnrequiredDeps") {
 							recurse = true;
+						} else if (_key == "NoUpdateHideIcon") {
+							noupdate_hide_icon = true;
 						}
 					}
 				} catch (GLib.Error e) {

--- a/src/pamac_config.vala
+++ b/src/pamac_config.vala
@@ -126,6 +126,17 @@ namespace Pamac {
 							} else {
 								data += line + "\n";
 							}
+						} else if (line.contains ("NoUpdateHideIcon")) {
+							if (new_conf.contains ("NoUpdateHideIcon")) {
+								bool _value = new_conf.get ("NoUpdateHideIcon").get_boolean ();
+								if (_value == true) {
+									data += "NoUpdateHideIcon\n";
+								} else {
+									data += "#NoUpdateHideIcon\n";
+								}
+							} else {
+								data += line + "\n";
+							}
 						} else {
 							data += line + "\n";
 						}

--- a/src/preferences_dialog.vala
+++ b/src/preferences_dialog.vala
@@ -29,6 +29,8 @@ namespace Pamac {
 		[GtkChild]
 		public Gtk.Switch check_space_button;
 		[GtkChild]
+		public Gtk.Switch noupdate_hide_icon_button;
+		[GtkChild]
 		public Gtk.Entry syncfirst_entry;
 		[GtkChild]
 		public Gtk.Entry ignore_upgrade_entry;

--- a/src/transaction.vala
+++ b/src/transaction.vala
@@ -837,6 +837,7 @@ namespace Pamac {
 			var preferences_dialog = new PreferencesDialog (window);
 			bool enable_aur = pamac_config.enable_aur;
 			bool recurse = pamac_config.recurse;
+			bool hide_icon = pamac_config.noupdate_hide_icon;
 			int refresh_period = pamac_config.refresh_period;
 			bool checkspace = get_checkspace ();
 			string syncfirst = get_syncfirst ();
@@ -845,6 +846,7 @@ namespace Pamac {
 			string choosen_country = mirrors_config.choosen_country;
 			preferences_dialog.enable_aur_button.set_active (enable_aur);
 			preferences_dialog.remove_unrequired_deps_button.set_active (recurse);
+			preferences_dialog.noupdate_hide_icon_button.set_active (hide_icon);
 			preferences_dialog.refresh_period_spin_button.set_value (refresh_period);
 			preferences_dialog.check_space_button.set_active (checkspace);
 			preferences_dialog.syncfirst_entry.set_text (syncfirst);
@@ -875,6 +877,7 @@ namespace Pamac {
 				var new_mirrors_conf = new HashTable<string,Variant> (str_hash, str_equal);
 				enable_aur = preferences_dialog.enable_aur_button.get_active ();
 				recurse = preferences_dialog.remove_unrequired_deps_button.get_active ();
+				hide_icon = preferences_dialog.noupdate_hide_icon_button.get_active ();
 				refresh_period = preferences_dialog.refresh_period_spin_button.get_value_as_int ();
 				checkspace = preferences_dialog.check_space_button.get_active ();
 				syncfirst = preferences_dialog.syncfirst_entry.get_text ();
@@ -890,6 +893,9 @@ namespace Pamac {
 				}
 				if (recurse != pamac_config.recurse) {
 					new_pamac_conf.insert ("RemoveUnrequiredDeps", new Variant.boolean (recurse));
+				}
+				if (hide_icon != pamac_config.noupdate_hide_icon) {
+					new_pamac_conf.insert ("NoUpdateHideIcon", new Variant.boolean (hide_icon));
 				}
 				if (refresh_period != pamac_config.refresh_period) {
 					new_pamac_conf.insert ("RefreshPeriod", new Variant.int32 (refresh_period));

--- a/src/transaction.vala
+++ b/src/transaction.vala
@@ -837,7 +837,7 @@ namespace Pamac {
 			var preferences_dialog = new PreferencesDialog (window);
 			bool enable_aur = pamac_config.enable_aur;
 			bool recurse = pamac_config.recurse;
-			bool hide_icon = pamac_config.noupdate_hide_icon;
+			bool noupdate_hide_icon = pamac_config.noupdate_hide_icon;
 			int refresh_period = pamac_config.refresh_period;
 			bool checkspace = get_checkspace ();
 			string syncfirst = get_syncfirst ();
@@ -846,7 +846,7 @@ namespace Pamac {
 			string choosen_country = mirrors_config.choosen_country;
 			preferences_dialog.enable_aur_button.set_active (enable_aur);
 			preferences_dialog.remove_unrequired_deps_button.set_active (recurse);
-			preferences_dialog.noupdate_hide_icon_button.set_active (hide_icon);
+			preferences_dialog.noupdate_hide_icon_button.set_active (noupdate_hide_icon);
 			preferences_dialog.refresh_period_spin_button.set_value (refresh_period);
 			preferences_dialog.check_space_button.set_active (checkspace);
 			preferences_dialog.syncfirst_entry.set_text (syncfirst);
@@ -877,7 +877,7 @@ namespace Pamac {
 				var new_mirrors_conf = new HashTable<string,Variant> (str_hash, str_equal);
 				enable_aur = preferences_dialog.enable_aur_button.get_active ();
 				recurse = preferences_dialog.remove_unrequired_deps_button.get_active ();
-				hide_icon = preferences_dialog.noupdate_hide_icon_button.get_active ();
+				noupdate_hide_icon = preferences_dialog.noupdate_hide_icon_button.get_active ();
 				refresh_period = preferences_dialog.refresh_period_spin_button.get_value_as_int ();
 				checkspace = preferences_dialog.check_space_button.get_active ();
 				syncfirst = preferences_dialog.syncfirst_entry.get_text ();
@@ -894,8 +894,8 @@ namespace Pamac {
 				if (recurse != pamac_config.recurse) {
 					new_pamac_conf.insert ("RemoveUnrequiredDeps", new Variant.boolean (recurse));
 				}
-				if (hide_icon != pamac_config.noupdate_hide_icon) {
-					new_pamac_conf.insert ("NoUpdateHideIcon", new Variant.boolean (hide_icon));
+				if (noupdate_hide_icon != pamac_config.noupdate_hide_icon) {
+					new_pamac_conf.insert ("NoUpdateHideIcon", new Variant.boolean (noupdate_hide_icon));
 				}
 				if (refresh_period != pamac_config.refresh_period) {
 					new_pamac_conf.insert ("RefreshPeriod", new Variant.int32 (refresh_period));

--- a/src/tray.vala
+++ b/src/tray.vala
@@ -156,6 +156,11 @@ namespace Pamac {
 						show_notification (info);
 					}
 				}
+				if (updates_nb == 0 && pamac_config.noupdate_hide_icon) {
+					status_icon.set_visible(false);
+				} else {
+					status_icon.set_visible(true);
+				}
 				stop_daemon ();
 			});
 		}


### PR DESCRIPTION
Hi! First off -- thank you for all the work that's been put into this tool!

`pamac-tray` is the only tray icon active on my machine most of the time, and it inspires gnome shell to show this little box:

![screenshot from 2015-08-01 12-22-21](https://cloud.githubusercontent.com/assets/767671/9021691/fcc93b74-3847-11e5-85c1-051768153aa7.png)

It's really useful when there are updates to apply, but as I don't use the tray icon to open the package manager, the icon is just a distraction for me the rest of the time.

I have added an option here to hide it when there are no updates, and would appreciate it if you would consider merging it. I have also tried to make it backwards compatible with the existing behaviour and defaults.

I've never written anything in `vala` before, so if there's any way that I could improve this for merging, I would appreciate the heads up. I'm very open to recommendations for better config/variable names too.

Hope this is handy!