### PR TITLE
[enh] improve Notification handling

### DIFF
--- a/src/tray.vala
+++ b/src/tray.vala
@@ -194,16 +194,6 @@ namespace Pamac {
 		}
 
 		void show_notification (string info) {
-//~ 				notification = new Notification (_("Update Manager"));
-//~ 				notification.set_body (info);
-//~ 				Gtk.IconTheme icon_theme = Gtk.IconTheme.get_default ();
-//~ 				Gdk.Pixbuf icon = icon_theme.load_icon ("system-software-update", 32, 0);
-//~ 				notification.set_icon (icon);
-//~ 				var action = new SimpleAction ("update", null);
-//~ 				action.activate.connect (execute_updater);
-//~ 				this.add_action (action);
-//~ 				notification.add_button (_("Show available updates"), "app.update");
-//~ 				this.send_notification (_("Update Manager"), notification);
 			try {
 				hide_notification();
 				notification = new Notify.Notification (_("Update Manager"), info, "system-software-update");

--- a/src/tray.vala
+++ b/src/tray.vala
@@ -195,9 +195,20 @@ namespace Pamac {
 //~ 				notification.add_button (_("Show available updates"), "app.update");
 //~ 				this.send_notification (_("Update Manager"), notification);
 			try {
+				hide_notification();
 				notification = new Notify.Notification (_("Update Manager"), info, "system-software-update");
 				notification.add_action ("update", _("Show available updates"), execute_updater);
 				notification.show ();
+			} catch (Error e) {
+				stderr.printf ("Notify Error: %s", e.message);
+			}
+		}
+
+		void hide_notification () {
+			try {
+				if(notification != null) {
+				 	notification.close();
+				}
 			} catch (Error e) {
 				stderr.printf ("Notify Error: %s", e.message);
 			}

--- a/src/tray.vala
+++ b/src/tray.vala
@@ -178,10 +178,19 @@ namespace Pamac {
 					status_icon.visible = true;
 					if (check_pamac_running () == false) {
 						show_notification (info);
+					} else {
+						update_notification (info);
 					}
 				}
 				stop_daemon ();
 			});
+		}
+
+		void on_notification_closed () {
+			int reason = notification.get_closed_reason();
+			if(reason == 2) { /* NOTIFYD_CLOSED_USER */
+				execute_updater ();
+			}
 		}
 
 		void show_notification (string info) {
@@ -198,10 +207,17 @@ namespace Pamac {
 			try {
 				hide_notification();
 				notification = new Notify.Notification (_("Update Manager"), info, "system-software-update");
-				notification.add_action ("update", _("Show available updates"), execute_updater);
+				// notification.add_action ("update", _("Show available updates"), execute_updater);
+				notification.closed.connect (on_notification_closed);
 				notification.show ();
 			} catch (Error e) {
 				stderr.printf ("Notify Error: %s", e.message);
+			}
+		}
+
+		void update_notification (string info) {
+			if(notification != null) {
+				 notification.update (_("Update Manager"), info, "system-software-update");
 			}
 		}
 

--- a/src/tray.vala
+++ b/src/tray.vala
@@ -171,7 +171,7 @@ namespace Pamac {
 					} else {
 						status_icon.visible = true;
 					}
-					hide_notification();
+					close_notification();
 				} else {
 					string info = ngettext ("%u available update", "%u available updates", updates_nb).printf (updates_nb);
 					this.update_icon (update_icon_name, info);
@@ -195,7 +195,7 @@ namespace Pamac {
 
 		void show_notification (string info) {
 			try {
-				hide_notification();
+				close_notification();
 				notification = new Notify.Notification (_("Update Manager"), info, "system-software-update");
 				// notification.add_action ("update", _("Show available updates"), execute_updater);
 				notification.closed.connect (on_notification_closed);
@@ -206,15 +206,25 @@ namespace Pamac {
 		}
 
 		void update_notification (string info) {
-			if(notification != null) {
-				 notification.update (_("Update Manager"), info, "system-software-update");
+			try {
+				if(notification != null) {
+					if(notification.get_closed_reason() == -1 && notification.body != info) {
+						notification.update (_("Update Manager"), info, "system-software-update");
+						notification.show ();
+					}
+				} else {
+					show_notification (info);
+				}
+			} catch (Error e) {
+				stderr.printf ("Notify Error: %s", e.message);
 			}
 		}
 
-		void hide_notification () {
+		void close_notification () {
 			try {
 				if(notification != null) {
 				 	notification.close();
+				 	notification = null;
 				}
 			} catch (Error e) {
 				stderr.printf ("Notify Error: %s", e.message);

--- a/src/tray.vala
+++ b/src/tray.vala
@@ -171,6 +171,7 @@ namespace Pamac {
 					} else {
 						status_icon.visible = true;
 					}
+					hide_notification();
 				} else {
 					string info = ngettext ("%u available update", "%u available updates", updates_nb).printf (updates_nb);
 					this.update_icon (update_icon_name, info);

--- a/src/tray.vala
+++ b/src/tray.vala
@@ -186,19 +186,11 @@ namespace Pamac {
 			});
 		}
 
-		void on_notification_closed () {
-			int reason = notification.get_closed_reason();
-			if(reason == 2) { /* NOTIFYD_CLOSED_USER */
-				execute_updater ();
-			}
-		}
-
 		void show_notification (string info) {
 			try {
 				close_notification();
 				notification = new Notify.Notification (_("Update Manager"), info, "system-software-update");
-				// notification.add_action ("update", _("Show available updates"), execute_updater);
-				notification.closed.connect (on_notification_closed);
+				notification.add_action ("default", _("Show available updates"), execute_updater);
 				notification.show ();
 			} catch (Error e) {
 				stderr.printf ("Notify Error: %s", e.message);


### PR DESCRIPTION
deleting old notifications to improve UX.

For example in Gnome, notifications would otherwise stay in the notification dash until they are closed manually.