### PR TITLE
added pkg.tar.gz

### DIFF
--- a/data/mime/x-alpm-package.xml
+++ b/data/mime/x-alpm-package.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0"?>
  <mime-info xmlns='http://www.freedesktop.org/standards/shared-mime-info'>
    <mime-type type="application/x-alpm-package">
-   <generic-icon name="package-x-generic"/> 
+   <generic-icon name="package-x-generic"/>
    <comment>Alpm Package</comment>
    <glob pattern="*.pkg.tar.xz"/>
+   <glob pattern="*.pkg.tar.gz"/>
   </mime-type>
  </mime-info>


### PR DESCRIPTION
In makepkg.conf another valid extension for packages is "pkg.tar.gz" instead of "pkg.tar.xz". I have pacman packages that are in the "pkg.tar.gz" format which are not detected by the mime type. This commit adds the other mime type.