### PR TITLE
Writing pacman-mirrors.conf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ po/*.mo
 po/*~
 po/locale
 *.swp
+/.idea/

--- a/src/mirrors_config.vala
+++ b/src/mirrors_config.vala
@@ -117,7 +117,7 @@ namespace Pamac {
 						if (line.contains ("Method")) {
 							if (new_conf.lookup_extended ("Method", null, out variant)) {
 								if (variant.get_string () == "rank") {
-									data.append ("# Method = \n".printf (line));
+									data.append ("# Method = \n".printf);
 								} else {
 									data.append ("Method = %s\n".printf (variant.get_string ()));
 								}
@@ -127,7 +127,7 @@ namespace Pamac {
 						} else if (line.contains ("OnlyCountry")) {
 							if (new_conf.lookup_extended ("OnlyCountry", null, out variant)) {
 								if (variant.get_string () == "ALL") {
-									data.append ("# OnlyCountry = \n".printf (line));
+									data.append ("# OnlyCountry = \n".printf);
 								} else {
 									data.append ("OnlyCountry = %s\n".printf (variant.get_string ()));
 								}

--- a/src/mirrors_config.vala
+++ b/src/mirrors_config.vala
@@ -117,7 +117,7 @@ namespace Pamac {
 						if (line.contains ("Method")) {
 							if (new_conf.lookup_extended ("Method", null, out variant)) {
 								if (variant.get_string () == "rank") {
-									data.append ("# Method = \n".printf);
+									data.append ("# Method = \n");
 								} else {
 									data.append ("Method = %s\n".printf (variant.get_string ()));
 								}
@@ -127,7 +127,7 @@ namespace Pamac {
 						} else if (line.contains ("OnlyCountry")) {
 							if (new_conf.lookup_extended ("OnlyCountry", null, out variant)) {
 								if (variant.get_string () == "ALL") {
-									data.append ("# OnlyCountry = \n".printf);
+									data.append ("# OnlyCountry = \n");
 								} else {
 									data.append ("OnlyCountry = %s\n".printf (variant.get_string ()));
 								}

--- a/src/mirrors_config.vala
+++ b/src/mirrors_config.vala
@@ -116,16 +116,20 @@ namespace Pamac {
 						unowned Variant variant;
 						if (line.contains ("Method")) {
 							if (new_conf.lookup_extended ("Method", null, out variant)) {
-								data.append ("Method=%s\n".printf (variant.get_string ()));
+								if (variant.get_string () == "rank") {
+									data.append ("# Method = \n".printf (line));
+								} else {
+									data.append ("Method = %s\n".printf (variant.get_string ()));
+								}
 							} else {
 								data.append (line + "\n");
 							}
 						} else if (line.contains ("OnlyCountry")) {
 							if (new_conf.lookup_extended ("OnlyCountry", null, out variant)) {
 								if (variant.get_string () == "ALL") {
-									data.append ("#%s\n".printf (line));
+									data.append ("# OnlyCountry = \n".printf (line));
 								} else {
-									data.append ("OnlyCountry=%s\n".printf (variant.get_string ()));
+									data.append ("OnlyCountry = %s\n".printf (variant.get_string ()));
 								}
 							} else {
 								data.append (line + "\n");


### PR DESCRIPTION
@guinux 
I have spotted some minor inconsistensies in writing **pacman-mirrors.conf**
The previous standard was to insert spaces around **`x = y`**.
Not having those affects pacman-mirrors in certain functions the app is checking the config file if a change should be written to a specific line. It has caused the change to be written to the end of the file.

    if "OnlyCountry = " in line then:

or

    if "Method = " in line then:

fails if it has been written as

    Method=

or

    OnlyCountry=