### PR TITLE
Don't Update Files Databases When Checking For Updates

### DIFF
--- a/src/user_daemon.vala
+++ b/src/user_daemon.vala
@@ -1197,14 +1197,6 @@ namespace Pamac {
 				db.update (0);
 				syncdbs.next ();
 			}
-			// refresh file dbs
-			var tmp_files_handle = alpm_config.get_handle (true, true);
-			syncdbs = tmp_files_handle.syncdbs;
-			while (syncdbs != null) {
-				unowned Alpm.DB db = syncdbs.data;
-				db.update (0);
-				syncdbs.next ();
-			}
 			string[] local_pkgs = {};
 			unowned Alpm.List<unowned Alpm.Package> pkgcache = tmp_handle.localdb.pkgcache;
 			while (pkgcache != null) {


### PR DESCRIPTION
Don't update files databases when checking for updates because files data is not needed to determine if updates are available and downloading the files data takes considerably more time than the package databases.

Fixes #368 