### PR TITLE
service waits for network

### DIFF
--- a/data/systemd/pamac-mirrorlist.service
+++ b/data/systemd/pamac-mirrorlist.service
@@ -1,7 +1,9 @@
 [Unit]
 Description=Generate mirrorlist
+Wants=network-online.target
+After=network-online.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/pacman-mirrors -f5
+ExecStart=/usr/bin/pacman-mirrors -f8
 ExecStartPost=/usr/bin/pacman -Syy

--- a/data/systemd/pamac-mirrorlist.timer
+++ b/data/systemd/pamac-mirrorlist.timer
@@ -2,7 +2,7 @@
 Description=Generate mirrorlist every fortnight
 
 [Timer]
-OnCalendar=*-*-1,15 0:00:00
+OnCalendar=*-*-1,15 8:00:00
 RandomizedDelaySec=12h
 Persistent=true
 


### PR DESCRIPTION
1. The service now waits to be online
2. The randomization starts at 8am to give more chance to the ones not having their machine on 24/7 to be at day time.
3. For someone living in Europe it is very reasonable to have a pool of 10 servers or more, there are 10 only in Germany. With `-f5` it happens that the 2-3 fastest mirrors in the pool are not picked up and I end up with a slow server, it is a pain. I must not be the only one in this situation. I would suggest something greater like `-f8` or `-f10` now that we have larger pools than before . It would not affect those who have a pool of 5 or less. Proposing `-f8` here.