### PR TITLE
Update org.manjaro.pamac.system.conf

### DIFF
--- a/data/dbus/org.manjaro.pamac.system.conf
+++ b/data/dbus/org.manjaro.pamac.system.conf
@@ -13,7 +13,7 @@
            send_interface="org.manjaro.pamac.system"/>
 
     <allow send_destination="org.manjaro.pamac.system"
-           send_interface="org.freedesktop.DBus_Introspectable"/>
+           send_interface="org.freedesktop.DBus.Introspectable"/>
     <allow send_destination="org.manjaro.pamac.system"
            send_interface="org.freedesktop.DBus.Peer"/>
     <allow send_destination="org.manjaro.pamac.system"


### PR DESCRIPTION
Fixed typo in default policy for `org.freedesktop.DBus.Introspectable`.

Without `DBus.Introspectable` no one can invoke methods on interfaces.