### PR TITLE
systemd timer fine tuning for cleancache and mirrorlist

### DIFF
--- a/data/systemd/pamac-cleancache.timer
+++ b/data/systemd/pamac-cleancache.timer
@@ -2,7 +2,7 @@
 Description=Monthly clean packages cache
 
 [Timer]
-OnCalendar=monthly
+OnCalendar=Sat *-*-1..7 15:00:00
 Persistent=true
 
 [Install]

--- a/data/systemd/pamac-mirrorlist.timer
+++ b/data/systemd/pamac-mirrorlist.timer
@@ -1,9 +1,9 @@
 [Unit]
-Description=Generate mirrorlist every fortnight
+Description=Generate mirrorlist weekly
 
 [Timer]
-OnCalendar=*-*-1,15 8:00:00
-RandomizedDelaySec=12h
+OnCalendar=Thu *-*-* 7:00:00
+RandomizedDelaySec=15h
 Persistent=true
 
 [Install]


### PR DESCRIPTION
Two systemd timer improvements:
* The monthly **cleancache** timer is moved to the first Saturday of the month to avoid the crowded 1st of the month at midnight (or the first boot of the month) - all the monthly processes run by default at the same time.
* The **mirrorlist** update (with network-online dependency) has been working fine every 2 weeks. I am proposing to switch to every Thursdays so that everybody is ready for the typical end of the week upgrade.

Thanks very much, don't hesitate to comment and I can adjust if needed.