### PR TITLE
Stop Downloading Database Files That Are The Same As Local Copies

### DIFF
--- a/src/alpm_config.vala
+++ b/src/alpm_config.vala
@@ -143,6 +143,7 @@ public class AlpmConfig {
 				Process.spawn_command_line_sync ("mkdir -p %s/sync".printf (tmp_dbpath));
 				Process.spawn_command_line_sync ("ln -sf %s/local %s".printf (dbpath, tmp_dbpath));
 				Process.spawn_command_line_sync ("chmod -R 777 %s/sync".printf (tmp_dbpath));
+				Process.spawn_command_line_sync ("cp %s/sync/*.{db,files} %s/sync".printf (dbpath, tmp_dbpath));
 				handle = new Alpm.Handle (rootdir, tmp_dbpath, out error);
 			} catch (SpawnError e) {
 				stderr.printf ("SpawnError: %s\n", e.message);


### PR DESCRIPTION
Copy existing database files into tmp directory before refreshing the databases that way alpm will only download database files that have changed since the last sync.

Fixes #368