### PR TITLE
Fix Bugs In The Commands Used To Setup Temp DBs

### DIFF
--- a/src/alpm_config.vala
+++ b/src/alpm_config.vala
@@ -141,9 +141,9 @@ public class AlpmConfig {
 			string tmp_dbpath = "/tmp/pamac-checkdbs";
 			try {
 				Process.spawn_command_line_sync ("mkdir -p %s/sync".printf (tmp_dbpath));
-				Process.spawn_command_line_sync ("ln -sf %s/local %s".printf (dbpath, tmp_dbpath));
+				Process.spawn_command_line_sync ("ln -sf %slocal %s".printf (dbpath, tmp_dbpath));
 				Process.spawn_command_line_sync ("chmod -R 777 %s/sync".printf (tmp_dbpath));
-				Process.spawn_command_line_sync ("cp %s/sync/*.{db,files} %s/sync".printf (dbpath, tmp_dbpath));
+				Process.spawn_command_line_sync ("bash -c 'cp %ssync/*.{db,files} %s/sync'".printf (dbpath, tmp_dbpath));
 				handle = new Alpm.Handle (rootdir, tmp_dbpath, out error);
 			} catch (SpawnError e) {
 				stderr.printf ("SpawnError: %s\n", e.message);


### PR DESCRIPTION
alpm_config.vala :: Fix copy command so that globbing and brace expansion works. Fix double path separator in both the link and copy commands.