### PR TITLE
use absolute path for vapidir

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -24,7 +24,7 @@ math = meson.get_compiler('c').find_library('m')
 vala_deps = [gobject]
 alpm_deps = [libalpm, gio, posix]
 
-alpm_vala_args = ['--vapidir=../vapi']
+alpm_vala_args = ['--vapidir=' + join_paths(meson.source_root(), 'vapi')]
 alpm_c_args = ['-D_FILE_OFFSET_BITS=64']
 
 common_vala_args = ['--pkg=posix', '--target-glib=2.38']


### PR DESCRIPTION
When I try to compile the project in GnomeBuilder I get the following errors:

```
[1/57] Compiling Vala source ../../../../../../Sources/github/pamac/src/common.vala ...ub/pamac/src/aur.vala ../../../../../../Sources/github/pamac/src/system_daemon.vala.
FAILED: src/pamac-system-daemon@exe/common.c src/pamac-system-daemon@exe/package.c src/pamac-system-daemon@exe/pamac_config.c src/pamac-system-daemon@exe/alpm_config.c src/pamac-system-daemon@exe/aur.c src/pamac-system-daemon@exe/system_daemon.c 
valac -C --debug --pkg appstream-glib --pkg libcurl --pkg polkit-gobject-1 --pkg libsoup-2.4 --pkg json-glib-1.0 --pkg posix --pkg gio-2.0 --pkg libalpm --pkg gobject-2.0 --color=always --directory src/pamac-system-daemon@exe --basedir ../../../../../../Sources/github/pamac/src --pkg=posix --target-glib=2.38 --vapidir=../vapi --thread ../../../../../../Sources/github/pamac/src/common.vala ../../../../../../Sources/github/pamac/src/package.vala ../../../../../../Sources/github/pamac/src/pamac_config.vala ../../../../../../Sources/github/pamac/src/alpm_config.vala ../../../../../../Sources/github/pamac/src/aur.vala ../../../../../../Sources/github/pamac/src/system_daemon.vala
error: Package `appstream-glib' not found in specified Vala API directories or GObject-Introspection GIR directories
error: Package `libcurl' not found in specified Vala API directories or GObject-Introspection GIR directories
error: Package `libalpm' not found in specified Vala API directories or GObject-Introspection GIR directories
Compilation failed: 3 error(s), 0 warning(s)
[2/57] Compiling Vala source ../../../../../../Sources/github/pamac/src/alpm_config....thub/pamac/src/aur.vala ../../../../../../Sources/github/pamac/src/user_daemon.vala.
FAILED: src/pamac-user-daemon@exe/alpm_config.c src/pamac-user-daemon@exe/common.c src/pamac-user-daemon@exe/package.c src/pamac-user-daemon@exe/aur.c src/pamac-user-daemon@exe/user_daemon.c 
valac -C --debug --pkg appstream-glib --pkg libsoup-2.4 --pkg json-glib-1.0 --pkg posix --pkg gio-2.0 --pkg libalpm --pkg gobject-2.0 --color=always --directory src/pamac-user-daemon@exe --basedir ../../../../../../Sources/github/pamac/src --pkg=posix --target-glib=2.38 --vapidir=../vapi --thread ../../../../../../Sources/github/pamac/src/alpm_config.vala ../../../../../../Sources/github/pamac/src/common.vala ../../../../../../Sources/github/pamac/src/package.vala ../../../../../../Sources/github/pamac/src/aur.vala ../../../../../../Sources/github/pamac/src/user_daemon.vala
error: Package `appstream-glib' not found in specified Vala API directories or GObject-Introspection GIR directories
error: Package `libalpm' not found in specified Vala API directories or GObject-Introspection GIR directories
Compilation failed: 2 error(s), 0 warning(s)
```

This patch fixes the errors