### PR TITLE
Fix User Daemon Updates Check

### DIFF
--- a/src/alpm_config.vala
+++ b/src/alpm_config.vala
@@ -140,10 +140,12 @@ public class AlpmConfig {
 		if (tmp_db) {
 			string tmp_dbpath = "/tmp/pamac-checkdbs";
 			try {
-				Process.spawn_command_line_sync ("mkdir -p %s/sync".printf (tmp_dbpath));
-				Process.spawn_command_line_sync ("ln -sf %slocal %s".printf (dbpath, tmp_dbpath));
-				Process.spawn_command_line_sync ("chmod -R 777 %s/sync".printf (tmp_dbpath));
-				Process.spawn_command_line_sync ("bash -c 'cp -p %ssync/*.{db,files} %s/sync'".printf (dbpath, tmp_dbpath));
+				if (! GLib.FileUtils.test(tmp_dbpath, GLib.FileTest.IS_DIR)) {
+					Process.spawn_command_line_sync ("mkdir -p %s/sync".printf (tmp_dbpath));
+					Process.spawn_command_line_sync ("ln -sf %slocal %s".printf (dbpath, tmp_dbpath));
+					Process.spawn_command_line_sync ("chmod -R 777 %s/sync".printf (tmp_dbpath));
+					Process.spawn_command_line_sync ("bash -c 'cp -p %ssync/*.{db,files} %s/sync'".printf (dbpath, tmp_dbpath));
+				}
 				handle = new Alpm.Handle (rootdir, tmp_dbpath, out error);
 			} catch (SpawnError e) {
 				stderr.printf ("SpawnError: %s\n", e.message);

--- a/src/alpm_config.vala
+++ b/src/alpm_config.vala
@@ -140,7 +140,7 @@ public class AlpmConfig {
 		if (tmp_db) {
 			string tmp_dbpath = "/tmp/pamac-checkdbs";
 			try {
-				if (! GLib.FileUtils.test(tmp_dbpath, GLib.FileTest.IS_DIR)) {
+				if (! GLib.FileUtils.test (tmp_dbpath, GLib.FileTest.IS_DIR)) {
 					Process.spawn_command_line_sync ("mkdir -p %s/sync".printf (tmp_dbpath));
 					Process.spawn_command_line_sync ("ln -sf %slocal %s".printf (dbpath, tmp_dbpath));
 					Process.spawn_command_line_sync ("chmod -R 777 %s/sync".printf (tmp_dbpath));


### PR DESCRIPTION
Don't try to create temporary database directory if it already exists as doing so triggers exception before the `handle` is set which causes update check to fail.

Fixes #331 