### PR TITLE
New option to disable tray feature [Suggestion from issue 433]

### DIFF
--- a/resources/preferences_dialog.ui
+++ b/resources/preferences_dialog.ui
@@ -280,6 +280,23 @@
                   </packing>
                 </child>
                 <child>
+                  <object class="GtkCheckButton" id="always_hide_icon_checkbutton">
+                    <property name="label" translatable="yes">Always hide tray icon</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="halign">start</property>
+                    <property name="margin_left">22</property>
+                    <property name="hexpand">True</property>
+                    <property name="draw_indicator">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">6</property>
+                  </packing>
+                </child>
+                <child>
                   <object class="GtkBox" id="ignorepkgs_box">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
@@ -399,7 +416,7 @@
                   <packing>
                     <property name="expand">True</property>
                     <property name="fill">True</property>
-                    <property name="position">6</property>
+                    <property name="position">7</property>
                   </packing>
                 </child>
               </object>

--- a/src/pamac_config.vala
+++ b/src/pamac_config.vala
@@ -25,6 +25,7 @@ namespace Pamac {
 		public bool recurse { get; private set; }
 		public uint64 refresh_period { get; private set; }
 		public bool no_update_hide_icon { get; private set; }
+		public bool always_hide_icon { get; private set; }
 		public bool enable_aur { get; private set; }
 		public string aur_build_dir { get; private set; }
 		public bool check_aur_updates { get; private set; }
@@ -72,6 +73,7 @@ namespace Pamac {
 			// set default options
 			recurse = false;
 			no_update_hide_icon = false;
+            always_hide_icon = false;
 			enable_aur = false;
 			aur_build_dir = "/tmp";
 			check_aur_updates = false;
@@ -118,6 +120,8 @@ namespace Pamac {
 							rm_only_uninstalled = true;
 						} else if (key == "NoUpdateHideIcon") {
 							no_update_hide_icon = true;
+                        } else if (key == "AlwaysHideIcon") {
+							always_hide_icon = true;
 						} else if (key == "EnableAUR") {
 							enable_aur = true;
 						} else if (key == "BuildDirectory") {
@@ -201,6 +205,17 @@ namespace Pamac {
 							} else {
 								data.append (line + "\n");
 							}
+						} else if (line.contains ("AlwaysHideIcon")) {
+							if (new_conf.lookup_extended ("AlwaysHideIcon", null, out variant)) {
+								if (variant.get_boolean ()) {
+									data.append ("AlwaysHideIcon\n");
+								} else {
+									data.append ("#AlwaysHideIcon\n");
+								}
+								new_conf.remove ("AlwaysHideIcon");
+							} else {
+								data.append (line + "\n");
+							}							
 						} else if (line.contains ("EnableAUR")) {
 							if (new_conf.lookup_extended ("EnableAUR", null, out variant)) {
 								if (variant.get_boolean ()) {
@@ -282,6 +297,12 @@ namespace Pamac {
 						} else {
 							data.append ("#NoUpdateHideIcon\n");
 						}
+					} else if (key =="AlwaysHideIcon") {
+						if (val.get_boolean ()) {
+							data.append ("AlwaysHideIcon\n");
+						} else {
+							data.append ("#AlwaysHideIcon\n");
+						}						
 					} else if (key == "EnableAUR") {
 						if (val.get_boolean ()) {
 							data.append ("EnableAUR\n");

--- a/src/pamac_config.vala
+++ b/src/pamac_config.vala
@@ -211,7 +211,7 @@ namespace Pamac {
 									data.append ("AlwaysHideIcon\n");
 								} else {
 									data.append ("#AlwaysHideIcon\n");
-								}
+                                }
 								new_conf.remove ("AlwaysHideIcon");
 							} else {
 								data.append (line + "\n");

--- a/src/preferences_dialog.vala
+++ b/src/preferences_dialog.vala
@@ -35,6 +35,8 @@ namespace Pamac {
 		[GtkChild]
 		Gtk.CheckButton no_update_hide_icon_checkbutton;
 		[GtkChild]
+		Gtk.CheckButton always_hide_icon_checkbutton;        
+		[GtkChild]
 		Gtk.CheckButton download_updates_checkbutton;
 		[GtkChild]
 		Gtk.Box ignorepkgs_box;
@@ -86,6 +88,7 @@ namespace Pamac {
 				refresh_period_spin_button.sensitive = false;
 				no_update_hide_icon_checkbutton.sensitive = false;
 				download_updates_checkbutton.sensitive = false;
+                always_hide_icon_checkbutton.sensitive = false;
 				ignorepkgs_box.sensitive = false;
 			} else {
 				check_updates_button.active = true;
@@ -94,6 +97,7 @@ namespace Pamac {
 			}
 			no_update_hide_icon_checkbutton.active = transaction.no_update_hide_icon;
 			download_updates_checkbutton.active = transaction.download_updates;
+            always_hide_icon_checkbutton.active = transaction.always_hide_icon;
 			cache_keep_nb_spin_button.value = transaction.keep_num_pkgs;
 			cache_only_uninstalled_checkbutton.active = transaction.rm_only_uninstalled;
 
@@ -110,6 +114,8 @@ namespace Pamac {
 			refresh_period_spin_button.value_changed.connect (on_refresh_period_spin_button_value_changed);
 			no_update_hide_icon_checkbutton.toggled.connect (on_no_update_hide_icon_checkbutton_toggled);
 			download_updates_checkbutton.toggled.connect (on_download_updates_checkbutton_toggled);
+            always_hide_icon_checkbutton.toggled.connect (on_always_hide_icon_checkbutton_toggled);
+
 			cache_keep_nb_spin_button.value_changed.connect (on_cache_keep_nb_spin_button_value_changed);
 			cache_only_uninstalled_checkbutton.toggled.connect (on_cache_only_uninstalled_checkbutton_toggled);
 			transaction.write_pamac_config_finished.connect (on_write_pamac_config_finished);
@@ -198,6 +204,12 @@ namespace Pamac {
 			new_pamac_conf.insert ("NoUpdateHideIcon", new Variant.boolean (no_update_hide_icon_checkbutton.active));
 			transaction.start_write_pamac_config (new_pamac_conf);
 		}
+		
+		void on_always_hide_icon_checkbutton_toggled () {
+			var new_pamac_conf = new HashTable<string,Variant> (str_hash, str_equal);
+			new_pamac_conf.insert ("AlwaysHideIcon", new Variant.boolean (always_hide_icon_checkbutton.active));
+			transaction.start_write_pamac_config (new_pamac_conf);
+		}		
 
 		void on_download_updates_checkbutton_toggled () {
 			var new_pamac_conf = new HashTable<string,Variant> (str_hash, str_equal);
@@ -224,7 +236,7 @@ namespace Pamac {
 			transaction.start_write_pamac_config (new_pamac_conf);
 		}
 
-		void on_write_pamac_config_finished (bool recurse, uint64 refresh_period, bool no_update_hide_icon,
+		void on_write_pamac_config_finished (bool recurse, uint64 refresh_period, bool no_update_hide_icon, bool always_hide_icon,
 											bool enable_aur, string aur_build_dir, bool check_aur_updates,
 											bool download_updates) {
 			remove_unrequired_deps_button.state = recurse;
@@ -233,6 +245,7 @@ namespace Pamac {
 				refresh_period_label.sensitive = false;
 				refresh_period_spin_button.sensitive = false;
 				no_update_hide_icon_checkbutton.sensitive = false;
+				always_hide_icon_checkbutton.sensitive = false;                
 				download_updates_checkbutton.sensitive = false;
 				ignorepkgs_box.sensitive = false;
 			} else {
@@ -242,11 +255,13 @@ namespace Pamac {
 				previous_refresh_period = refresh_period;
 				refresh_period_spin_button.sensitive = true;
 				no_update_hide_icon_checkbutton.sensitive = true;
+                always_hide_icon_checkbutton.sensitive = true;  
 				download_updates_checkbutton.sensitive = true;
 				ignorepkgs_box.sensitive = true;
 			}
 			no_update_hide_icon_checkbutton.active = no_update_hide_icon;
 			download_updates_checkbutton.active = download_updates;
+            always_hide_icon_checkbutton.active = always_hide_icon;
 			enable_aur_button.state = enable_aur;
 			aur_build_dir_label.sensitive = enable_aur;
 			aur_build_dir_file_chooser.sensitive = enable_aur;

--- a/src/transaction.vala
+++ b/src/transaction.vala
@@ -90,7 +90,7 @@ namespace Pamac {
 		public signal void trans_prepare_finished (bool success);
 		public signal void trans_commit_finished (bool success);
 		public signal void get_authorization_finished (bool authorized);
-		public signal void write_pamac_config_finished (bool recurse, uint64 refresh_period, bool no_update_hide_icon,
+		public signal void write_pamac_config_finished (bool recurse, uint64 refresh_period, bool no_update_hide_icon, bool always_hide_icon,
 														bool enable_aur, string aur_build_dir, bool check_aur_updates,
 														bool download_updates);
 		public signal void write_alpm_config_finished (bool checkspace);
@@ -120,6 +120,7 @@ namespace Pamac {
 		public bool enable_aur { get { return pamac_config.enable_aur; }  }
 		public unowned GLib.HashTable<string,string> environment_variables { get {return pamac_config.environment_variables; } }
 		public bool no_update_hide_icon { get { return pamac_config.no_update_hide_icon; } }
+		public bool always_hide_icon { get { return pamac_config.always_hide_icon; } }		
 		public bool download_updates { get { return pamac_config.download_updates; } }
 		public bool recurse { get { return pamac_config.recurse; } }
 		public uint64 refresh_period { get { return pamac_config.refresh_period; } }
@@ -178,7 +179,7 @@ namespace Pamac {
 		public signal void important_details_outpout (bool must_show);
 		public signal void finished (bool success);
 		public signal void set_pkgreason_finished ();
-		public signal void write_pamac_config_finished (bool recurse, uint64 refresh_period, bool no_update_hide_icon,
+		public signal void write_pamac_config_finished (bool recurse, uint64 refresh_period, bool no_update_hide_icon, bool always_hide_icon,
 														bool enable_aur, string aur_build_dir, bool check_aur_updates,
 														bool download_updates);
 		public signal void write_alpm_config_finished (bool checkspace);
@@ -1820,7 +1821,7 @@ namespace Pamac {
 			set_pkgreason_finished ();
 		}
 
-		void on_write_pamac_config_finished (bool recurse, uint64 refresh_period, bool no_update_hide_icon,
+		void on_write_pamac_config_finished (bool recurse, uint64 refresh_period, bool no_update_hide_icon, bool always_hide_icon,
 												bool enable_aur, string aur_build_dir, bool check_aur_updates) {
 			system_daemon.write_pamac_config_finished.disconnect (on_write_pamac_config_finished);
 			pamac_config.reload ();
@@ -1828,7 +1829,7 @@ namespace Pamac {
 			if (pamac_config.recurse) {
 				flags |= (1 << 5); //Alpm.TransFlag.RECURSE
 			}
-			write_pamac_config_finished (recurse, refresh_period, no_update_hide_icon,
+			write_pamac_config_finished (recurse, refresh_period, no_update_hide_icon, always_hide_icon,
 										enable_aur, aur_build_dir, check_aur_updates,
 										download_updates);
 		}

--- a/src/tray-appindicator.vala
+++ b/src/tray-appindicator.vala
@@ -47,12 +47,12 @@ namespace Pamac {
 			return indicator_status_icon.get_icon ();
 		}
 
-		public override void set_icon_visible (bool visible) {
-            if (visible) {
-                indicator_status_icon.set_status (AppIndicator.IndicatorStatus.ACTIVE);
-            } else {
+		public override void set_icon_visible (bool visible, bool forceHide) {
+            if (visible && !forceHide) {
+				indicator_status_icon.set_status (AppIndicator.IndicatorStatus.ACTIVE);
+			} else {
                 indicator_status_icon.set_status (AppIndicator.IndicatorStatus.PASSIVE);
-            }
+			}            
 		}
 	}
 }

--- a/src/tray-appindicator.vala
+++ b/src/tray-appindicator.vala
@@ -48,11 +48,11 @@ namespace Pamac {
 		}
 
 		public override void set_icon_visible (bool visible) {
-			if (visible) {
-				indicator_status_icon.set_status (AppIndicator.IndicatorStatus.ACTIVE);
-			} else {
-				indicator_status_icon.set_status (AppIndicator.IndicatorStatus.PASSIVE);
-			}
+            if (visible) {
+                indicator_status_icon.set_status (AppIndicator.IndicatorStatus.ACTIVE);
+            } else {
+                indicator_status_icon.set_status (AppIndicator.IndicatorStatus.PASSIVE);
+            }
 		}
 	}
 }

--- a/src/tray-gtk.vala
+++ b/src/tray-gtk.vala
@@ -46,8 +46,8 @@ namespace Pamac {
 			return status_icon.get_icon_name ();
 		}
 
-		public override void set_icon_visible (bool visible) {
-			if (visible) {
+		public override void set_icon_visible (bool visible, bool forceHide) {
+            if (visible && !forceHide) {
 				status_icon.visible = true;
 			} else {
 				status_icon.visible = false;

--- a/src/tray.vala
+++ b/src/tray.vala
@@ -147,7 +147,7 @@ namespace Pamac {
 
 		public abstract string get_icon ();
 
-		public abstract void set_icon_visible (bool visible);
+		public abstract void set_icon_visible (bool visible, bool forceHide);
 
 		bool check_updates () {
 			var pamac_config = new Pamac.Config ("/etc/pamac.conf");
@@ -167,7 +167,7 @@ namespace Pamac {
 			if (updates_nb == 0) {
 				set_icon (noupdate_icon_name);
 				set_tooltip (noupdate_info);
-				set_icon_visible (!pamac_config.no_update_hide_icon);
+				set_icon_visible (!pamac_config.no_update_hide_icon, pamac_config.always_hide_icon);
 				close_notification ();
 			} else {
 				if (!check_pamac_running () && pamac_config.download_updates) {
@@ -190,10 +190,11 @@ namespace Pamac {
 		}
 
 		void show_or_update_notification () {
+            var pamac_config = new Pamac.Config ("/etc/pamac.conf");
 			string info = ngettext ("%u available update", "%u available updates", updates_nb).printf (updates_nb);
 			set_icon (update_icon_name);
 			set_tooltip (info);
-			set_icon_visible (true);
+			set_icon_visible (true, pamac_config.always_hide_icon);
 			if (check_pamac_running ()) {
 				update_notification (info);
 			} else {
@@ -312,7 +313,13 @@ namespace Pamac {
 			init_status_icon ();
 			set_icon (noupdate_icon_name);
 			set_tooltip (noupdate_info);
-			set_icon_visible (!pamac_config.no_update_hide_icon);
+            
+            if (pamac_config.always_hide_icon) {
+                set_icon_visible(false, pamac_config.always_hide_icon);
+            }
+            else {
+                set_icon_visible (!pamac_config.no_update_hide_icon, pamac_config.always_hide_icon);
+            }
 
 			Notify.init (_("Package Manager"));
 


### PR DESCRIPTION
Small modification to the preferences dialog to specify disabling the tray. Adds a new flag to /etc/pamac.conf and modification to the tray icon code to look for the flag and ignore any updates.

Idea from feature request 433 https://github.com/manjaro/pamac/issues/433 