### PR TITLE
Update extension for gnome 47

### DIFF
--- a/data/gnome-shell/pamac-updates@manjaro.org/metadata.json
+++ b/data/gnome-shell/pamac-updates@manjaro.org/metadata.json
@@ -1,9 +1,9 @@
 {
   "description": "GNOME Shell Updates indicator for Pamac.", 
   "name": "Pamac Updates Indicator",
-  "shell-version": ["45", "46"],
+  "shell-version": ["45", "46", "47"],
   "url": "https://gitlab.manjaro.org/applications/pamac", 
   "uuid": "pamac-updates@manjaro.org", 
   "gettext-domain": "pamac",
-  "version": 11
+  "version": 12
 }


### PR DESCRIPTION
Tested it out briefly and seems to work just fine in gnome 47.