### PR TITLE
Add jemalloc support

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -4,6 +4,19 @@ project('pamac', 'c', 'vala',
 		'sysconfdir=/etc',],
 		version : '11.7.3')
 
+# jemalloc option handling
+jemalloc_opt = get_option('jemalloc')
+if jemalloc_opt == 'true'
+  jemalloc = dependency('jemalloc', required: true)
+  use_jemalloc = true
+elif jemalloc_opt == 'auto'
+  jemalloc = dependency('jemalloc', required: false)
+  use_jemalloc = jemalloc.found()
+else
+  jemalloc = dependency('', required: false)
+  use_jemalloc = false
+endif
+
 subdir('resources')
 subdir('src')
 subdir('data')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,1 +1,4 @@
 option('enable-fake-gnome-software', type : 'boolean', value : false, description : 'simulate gnome-software')
+
+option('jemalloc', type : 'combo', choices : ['true', 'false', 'auto'], value : 'auto',
+       description: 'Use jemalloc memory allocator if available (auto = enable if found)')

--- a/src/meson.build
+++ b/src/meson.build
@@ -9,48 +9,86 @@ gtk3 = dependency('gtk+-3.0', version : '>=3.24')
 gtk4 = dependency('gtk4', version : '>=4.10')
 libadwaita = dependency('libadwaita-1', version : '>=1.4')
 
+# jemalloc option handling (duplicated from top-level meson.build)
+jemalloc_opt = get_option('jemalloc')
+if jemalloc_opt == 'true'
+  use_jemalloc = true
+elif jemalloc_opt == 'auto'
+  jemalloc = dependency('jemalloc', required: false).found()
+  use_jemalloc = jemalloc
+else
+  use_jemalloc = false
+endif
 
 common_vala_args = ['--pkg=posix', '--vapidir=' + join_paths(meson.global_source_root(), 'vapi')]
+
 common_c_args = ['-DGETTEXT_PACKAGE="pamac"']
+jemalloc_link_args = []
+if use_jemalloc
+  jemalloc_link_args += ['-Wl,--no-as-needed', '-ljemalloc', '-Wl,--as-needed']
+endif
 
+tray_deps = [gtk3, libnotify, libpamac]
+tray_link_with = []
+if use_jemalloc
+  tray_link_with += jemalloc
+endif
 executable('pamac-tray',
-	sources: ['tray.vala', 'tray-gtk.vala'],
-	dependencies: [gtk3, libnotify, libpamac],
-	vala_args: common_vala_args,
-	c_args: common_c_args,
-	install: true)
+  sources: ['tray.vala', 'tray-gtk.vala'],
+  dependencies: tray_deps,
+  vala_args: common_vala_args,
+  c_args: common_c_args,
+  install: true)
 
+libpamac_gtk_deps = [gtk4, libadwaita, libpamac]
+libpamac_gtk_link_with = []
+if use_jemalloc
+  libpamac_gtk_link_with += jemalloc
+endif
 libpamac_gtk = library('pamac-gtk',
-	sources: ['transaction-gtk.vala', 'choose_provider_dialog.vala', 'choose_pkgs_dialog.vala',
-			'transaction_sum_dialog.vala', 'summary_row.vala', 'progress_box.vala', 'version.vala',
-			'local_config.vala', 'database-gtk.vala', transaction_resources],
-	dependencies: [gtk4, libadwaita, libpamac],
-	vala_args: common_vala_args,
-	c_args: common_c_args,
-	install: true,
-	install_dir: [true])
+  sources: ['transaction-gtk.vala', 'choose_provider_dialog.vala', 'choose_pkgs_dialog.vala',
+    'transaction_sum_dialog.vala', 'summary_row.vala', 'progress_box.vala', 'version.vala',
+    'local_config.vala', 'database-gtk.vala', transaction_resources],
+  dependencies: libpamac_gtk_deps,
+  vala_args: common_vala_args,
+  c_args: common_c_args,
+  link_args: jemalloc_link_args,
+  install: true,
+  install_dir: [true])
 
 libpamac_gtk_dep = declare_dependency(link_with: libpamac_gtk)
 
+manager_deps = [gtk4, libadwaita, gio_unix, libpamac, libpamac_gtk_dep]
+manager_link_with = []
+if use_jemalloc
+  manager_link_with += jemalloc
+endif
 executable('pamac-manager',
-	sources: ['version.vala', 'history_dialog.vala', 'updates_dialog.vala', 'preferences_dialog.vala',
-			'package_row.vala', 'simple_row.vala', 'back_row.vala', 'manager_window.vala', 'manager.vala',
-			'search-provider.vala', manager_resources],
-	dependencies: [gtk4, libadwaita, gio_unix, libpamac, libpamac_gtk_dep],
-	vala_args: common_vala_args,
-	c_args: common_c_args,
-	install: true)
+  sources: ['version.vala', 'history_dialog.vala', 'updates_dialog.vala', 'preferences_dialog.vala',
+    'package_row.vala', 'simple_row.vala', 'back_row.vala', 'manager_window.vala', 'manager.vala',
+    'search-provider.vala', manager_resources],
+  dependencies: manager_deps,
+  vala_args: common_vala_args,
+  c_args: common_c_args,
+  link_args: jemalloc_link_args,
+  install: true)
 
 if get_option('enable-fake-gnome-software')
-	executable('gnome-software',
-		sources: ['fake_gnome_software.vala'],
-		dependencies: [gio],
-		install: true)
+  executable('gnome-software',
+    sources: ['fake_gnome_software.vala'],
+    dependencies: [gio],
+    install: true)
 endif
 
+installer_deps = [gtk4, libadwaita, gio_unix, libpamac, libpamac_gtk_dep]
+installer_link_with = []
+if use_jemalloc
+  installer_link_with += jemalloc
+endif
 executable('pamac-installer',
-	sources: ['progress_dialog.vala', 'installer.vala', installer_resources],
-	dependencies: [gtk4, libadwaita, gio_unix, libpamac, libpamac_gtk_dep],
-	vala_args: common_vala_args,
-	c_args: common_c_args,
-	install: true)
+  sources: ['progress_dialog.vala', 'installer.vala', installer_resources],
+  dependencies: installer_deps,
+  vala_args: common_vala_args,
+  c_args: common_c_args,
+  link_args: jemalloc_link_args,
+  install: true)


### PR DESCRIPTION
### Add Support for Jemalloc

This PR introduces support for jemalloc as an alternative memory allocator in Pamac.

**Why Jemalloc?**  
Jemalloc is often more efficient than the default GCC `malloc` in various scenarios. It is available in the repositories of almost all major distributions and is the default memory allocator on FreeBSD. For more details on where jemalloc is used, refer to the [background documentation](https://github.com/jemalloc/jemalloc/wiki/Background).

**Repository Status Note**  
For reasons unknown to me, the jemalloc repository is sometimes archived and then unarchived for updates before being archived again.

**How to Enable**  
With these changes, you only need to add jemalloc as a dependency in the `PKGBUILD`. When building the package, jemalloc will be used as a replacement for GCC’s malloc automatically.

**Test Results**  
I have tested these changes on two computers and observed similar improvements in memory usage:

- **With AUR enabled:**
  - Before: 1026 MB
  - After: 612 MB

- **Without AUR:**
  - Before: 370 MB
  - After: 152 MB  
    (Starts at 290 MB and drops to 152 MB within a few seconds)

**How to Verify Jemalloc is in Use**  
To confirm that jemalloc is being used, you can check with `ldd`:
```sh
ldd /usr/bin/pamac-manager | grep malloc
```