### PR TITLE
fix(ui): Keep cancel button enabled during transaction dependency resolution

### DIFF
--- a/src/manager_window.vala
+++ b/src/manager_window.vala
@@ -1,20 +1,20 @@
 /*
- *  pamac-vala
+ * pamac-vala
  *
- *  Copyright (C) 2014-2023 Guillaume Benoit <guillaume@manjaro.org>
+ * Copyright (C) 2014-2023 Guillaume Benoit <guillaume@manjaro.org>
  *
- *  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
  *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  *
- *  You should have received a get of the GNU General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * You should have received a get of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 namespace Pamac {
@@ -3895,7 +3895,7 @@ namespace Pamac {
 			transaction.no_confirm_upgrade = no_confirm_upgrade;
 			transaction_running = true;
 			apply_button.sensitive = false;
-			cancel_button.sensitive = false;
+			cancel_button.sensitive = true;
 			foreach (unowned string name in to_install) {
 				transaction.add_pkg_to_install (name);
 				previous_to_install.add (name);
@@ -4149,7 +4149,6 @@ namespace Pamac {
 		}
 
 		void on_stop_preparing () {
-			cancel_button.sensitive = false;
 			this.set_cursor (new Gdk.Cursor.from_name ("default", null));
 		}
 
@@ -4158,7 +4157,6 @@ namespace Pamac {
 		}
 
 		void on_stop_downloading () {
-			cancel_button.sensitive = false;
 		}
 
 		void on_start_building () {
@@ -4166,7 +4164,6 @@ namespace Pamac {
 		}
 
 		void on_stop_building () {
-			cancel_button.sensitive = false;
 		}
 
 		void on_important_details_outpout (bool must_show) {


### PR DESCRIPTION
When initiating a package transaction that requires resolving complex dependencies, the user can become trapped in a series of modal dialogs asking for input on optional dependencies or providers. During this interactive phase, the main "Cancel" button in the transaction window is disabled, providing no UI mechanism to abort the process. This forces the user to either complete all prompts—which can be numerous—or terminate the application forcefully.

The root cause of this issue lies in the state management of the "Cancel" button's sensitivity. The run_transaction function would immediately disable the cancel button upon starting. Subsequent callbacks like on_stop_preparing, on_stop_downloading, and on_stop_building also explicitly set the button's sensitivity to false. While the transaction was technically paused and waiting for user input from a dependency dialog, the button remained disabled, preventing the user from aborting.

This fix addresses the issue by modifying the transaction state logic to ensure the "Cancel" button remains active. The button's sensitive property is now set to true at the beginning of the run_transaction function and is no longer disabled during the subsequent phases of the operation. This ensures that the user retains control and can gracefully cancel a transaction at any point, leading to a more responsive and user-friendly experience.

How Has This Been Tested?
Start a package installation that is known to have multiple optional dependencies or provider conflicts (e.g., python-matplotlib-git).

Proceed with the installation until the first dependency resolution dialog appears.

Verify that the "Cancel" button on the main transaction window remains active and is not greyed out.

Click the "Cancel" button.

Observe that the transaction is aborted and the application returns to its previous state without getting stuck.

Types of changes
[x] Bug fix (non-breaking change which fixes an issue)

[ ] New feature (non-breaking change which adds functionality)

[ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Checklist:
[x] My code follows the style guidelines of this project

[x] I have performed a self-review of my own code

[x] I have commented my code, particularly in hard-to-understand areas

[ ] I have made corresponding changes to the documentation

[x] My changes generate no new warnings

[ ] I have added tests that prove my fix is effective or that my feature works

[x] New and existing unit tests pass locally with my changes