### PR TITLE
Update gnome extension from manjaro gitlab to github 

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+## Describe the issue 
+A clear and concise description of what the issue is
+
+## To Reproduce
+How to reproduce reliably 
+
+## Expected behavior versus observed behavior
+A clear and concise description of what you expected to happen.
+
+## Screenshots/Video
+If applicable, add screenshots/video to help explain your problem.
+If possible add logging output from: 
+ - Journal (eg: `journalctl --follow`)
+ - [looking-glass](https://gjs.guide/extensions/development/debugging.html#looking-glass)  for the gnome extension
+
+## System to replicate the issue on
+ - output of inxi -b to have some idea of the system pamac is run on.
+ - Manjaro [XFCE|KDE|Gnome] Branch [Stable|testing|unstable]
+ - Arch [DE/WM] Branch [testing|stable]
+ - Pamac [x.x] Libpamac [x.x]
+
+## Additional context
+Add any other context about the problem here.

--- a/data/gnome-shell/pamac-updates@manjaro.org/metadata.json
+++ b/data/gnome-shell/pamac-updates@manjaro.org/metadata.json
@@ -2,7 +2,7 @@
   "description": "GNOME Shell Updates indicator for Pamac.", 
   "name": "Pamac Updates Indicator",
   "shell-version": ["45", "46", "47", "48", "49"],
-  "url": "https://gitlab.manjaro.org/applications/pamac", 
+  "url": "https://github.com/manjaro/pamac", 
   "uuid": "pamac-updates@manjaro.org", 
   "gettext-domain": "pamac",
   "version": 11


### PR DESCRIPTION
The gnome extension meta data points to the Manjaro gitlab instance URL but that repository is read only and archived. Changed to the current project where active development is taking place.